### PR TITLE
Fix textures and sprites not being viewable.

### DIFF
--- a/src/UnityExplorer/UI/Widgets/UnityObjects/Texture2DWidget.cs
+++ b/src/UnityExplorer/UI/Widgets/UnityObjects/Texture2DWidget.cs
@@ -43,7 +43,7 @@ namespace UnityExplorerForLobotomyCorporation.UnityExplorer.UI.Widgets.UnityObje
             }
             else if (target.TryCast<Sprite>() is Sprite sprite)
             {
-                if (sprite.packingMode == SpritePackingMode.Tight)
+                if (sprite.packed && sprite.packingMode == SpritePackingMode.Tight)
                 {
                     texture = sprite.texture;
                 }
@@ -55,7 +55,7 @@ namespace UnityExplorerForLobotomyCorporation.UnityExplorer.UI.Widgets.UnityObje
             }
             else if (target.TryCast<Image>() is Image image)
             {
-                if (image.sprite.packingMode == SpritePackingMode.Tight)
+                if (image.sprite.packed && image.sprite.packingMode == SpritePackingMode.Tight)
                 {
                     texture = image.sprite.texture;
                 }


### PR DESCRIPTION
Ensure that textures are only assigned from packed sprites with tight packing mode. This prevents texture assignment from sprites that are not packed, which could cause unintended behavior.